### PR TITLE
chore: add initial project structure and setup for Order Signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,107 @@
-# order-signal
+# Order Signal
+
+<!-- Badges -->
+![.NET 8](https://img.shields.io/badge/.NET-8.0-512BD4?logo=dotnet&logoColor=white)
+![MassTransit](https://img.shields.io/badge/MassTransit-8.x-0FA9A7)
+![RabbitMQ](https://img.shields.io/badge/RabbitMQ-3.x-FF6600?logo=rabbitmq&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/Postgres-16-336791?logo=postgresql&logoColor=white)
+![SignalR](https://img.shields.io/badge/SignalR-realtime-2C3E50)
+![Firebase](https://img.shields.io/badge/Firebase-Cloud%20Messaging-FFCA28?logo=firebase&logoColor=black)
+
+**Order Signal** is a showcase project demonstrating a modern event-driven backend in **.NET 8**.  
+Scope of the MVP: create an order, update its status, publish an event, process it in a worker, and notify the user in real time (SignalR + Firebase).
+
+> This is a study/portfolio project, not a production system.
+
+
+## Tech Stack (MVP)
+- .NET 8 (ASP.NET Core, Background services)
+- MassTransit + RabbitMQ (event-driven, outbox)
+- EF Core + PostgreSQL (persistence) — provider TBD in the MVP
+- SignalR (real-time updates), Firebase Cloud Messaging (push)
+- Testing: xUnit (unit), Testcontainers (integration) — later
+
+
+## Repository Structure
+
+```text
+order-signal/
+├─ src/
+│  ├─ OrderSignal.Api/
+│  │  ├─ OrderSignal.Api.csproj
+│  │  ├─ Program.cs
+│  │  └─ (Controllers/, Hubs/, etc.)
+│  ├─ OrderSignal.Worker/
+│  │  ├─ OrderSignal.Worker.csproj
+│  │  └─ Program.cs
+│  └─ OrderSignal.Contracts/
+│     └─ OrderSignal.Contracts.csproj
+├─ tests/
+│  └─ OrderSignal.Unit/
+│     └─ OrderSignal.Unit.csproj
+├─ docs/
+│  ├─ roadmap.md
+│  └─ adr/
+├─ .gitignore
+├─ order-signal.sln
+└─ README.md
+```
+
+## Current Status
+- ✅ Repo scaffold created
+- 🟡 Implementing MVP (see [docs/roadmap.md](./docs/roadmap.md))
+- ⏭️ Next: add MassTransit + Outbox, publish events from API, basic consumer
+
+➡️ Project board: [Order Signal showcase](https://github.com/<user>/order-signal/projects/<id>)
+
+## Quickstart (WIP)
+For now, run the projects locally:
+
+```bash
+# API
+dotnet run --project src/OrderSignal.Api/OrderSignal.Api.csproj
+
+# Worker
+dotnet run --project src/OrderSignal.Worker/OrderSignal.Worker.csproj
+
+# Docker Compose (Postgres + RabbitMQ) will be added soon.
+```
+
+## Architecture (high level)
+
+```mermaid
+flowchart LR
+    A[API Create/Update Order] -->|publish event| B[(Outbox/Bus)]
+    B --> C([RabbitMQ])
+    C --> D[Worker - Consumer]
+    D --> E[SignalR Hub]
+    D --> F[Firebase Push]
+    E & F --> G[User]
+```
+---
+
+## Events (planned)
+
+- `OrderCreated { OrderId, UserId, OccurredAt }`
+- `OrderStatusChanged { OrderId, UserId, Status, OccurredAt }`
+
+**Headers (planned):**
+- `correlationId`
+- `causationId`
+- `eventType`
+- `eventVersion`
+
+---
+
+## Roadmap
+
+- [ ] Setup Docker Compose (Postgres + RabbitMQ) — [#3](https://github.com/VirginioBruno/order-signal/issues/3)
+- [ ] Implement API routes: create/update orders — [#2](https://github.com/VirginioBruno/order-signal/issues/2), [#6](https://github.com/VirginioBruno/order-signal/issues/6)
+- [ ] Add MassTransit with Outbox pattern — [#4](https://github.com/VirginioBruno/order-signal/issues/4)
+- [ ] Worker consumes events and logs — [#5](https://github.com/VirginioBruno/order-signal/issues/5)
+- [ ] Add SignalR hub + demo page — [#8](https://github.com/VirginioBruno/order-signal/issues/8)
+- [ ] Register device token endpoint — [#9](https://github.com/VirginioBruno/order-signal/issues/9)
+- [ ] Firebase push notifications — [#7](https://github.com/VirginioBruno/order-signal/issues/7)
+- [ ] Initial documentation — [#10](https://github.com/VirginioBruno/order-signal/issues/10)
+
+➡️ More details in [docs/roadmap.md](./docs/roadmap.md).

--- a/docs/adr/0001-monorepo-first.md
+++ b/docs/adr/0001-monorepo-first.md
@@ -1,0 +1,14 @@
+# ADR 0001 — Monorepo First
+
+## Context
+Order Signal has two main processes (API, Worker) and shared event contracts.  
+We could split into multiple repositories or keep everything in a single repository.
+
+## Decision
+Adopt a **monorepo** for API, Worker and Contracts.
+
+## Consequences
+- ✅ Simplifies setup (one clone, one solution, one docker-compose).
+- ✅ Easier for learning and showcasing in interviews.
+- ✅ Contracts can be referenced directly by API and Worker.
+- ⚠️ If the system grows, we can extract services and publish `OrderSignal.Contracts` as a NuGet package.

--- a/docs/adr/_template.md
+++ b/docs/adr/_template.md
@@ -1,0 +1,10 @@
+# ADR 000X — [Title]
+
+## Context
+[Why this decision?]
+
+## Decision
+[What we chose.]
+
+## Consequences
+[What becomes easier or harder?]

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,34 @@
+# Roadmap
+
+## Phase 1 — Boot
+- [x] Create initial project structure
+- [ ] Setup Docker Compose (Postgres + RabbitMQ)
+
+## Phase 2 — Core
+- [ ] API: POST /orders (persist to DB)
+- [ ] API: PUT /orders/{id}/status (update order status)
+
+## Phase 3 — Messaging
+- [ ] Add MassTransit + Outbox pattern
+- [ ] Define event contracts (OrderCreated, OrderStatusChanged)
+- [ ] Publish events from API (Bus Outbox)
+- [ ] Worker consumes events (Consumer Outbox, logs first)
+
+## Phase 4 — Notifications
+- [ ] Add SignalR hub + demo page
+- [ ] Register Firebase device token
+- [ ] Push notifications via Firebase
+
+## Phase 5 — Documentation
+- [ ] Initial documentation in `README.md`
+- [ ] ADR-0001 Monorepo First
+- [ ] ADR-0002 Outbox with MassTransit
+
+---
+
+## Future Enhancements
+- Dead Letter Queue + reprocess endpoint
+- Observability with OpenTelemetry (traces + metrics)
+- AsyncAPI for event contracts
+- Saga orchestration (inventory/payment/shipping)
+- Kubernetes deployment (probes, scaling)

--- a/order-signal.sln
+++ b/order-signal.sln
@@ -1,0 +1,50 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4E1530E0-EC90-4B1A-ADEC-04B52B83056E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrderSignal.Api", "src\OrderSignal.Api\OrderSignal.Api.csproj", "{95764993-7C67-4C0B-8AFD-41C76A0A203B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrderSignal.Worker", "src\OrderSignal.Worker\OrderSignal.Worker.csproj", "{F474C23D-FAC7-45BC-B21F-7915ABE7F461}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrderSignal.Contracts", "src\OrderSignal.Contracts\OrderSignal.Contracts.csproj", "{09804FCD-B506-4879-AE30-EF0DDCD87402}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{50F530E7-FD4B-4548-989E-2A0F258468FE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrderSignal.Unit", "tests\OrderSignal.Unit\OrderSignal.Unit.csproj", "{988A96F0-18D7-480A-9CDB-B804CD9B743C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{95764993-7C67-4C0B-8AFD-41C76A0A203B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95764993-7C67-4C0B-8AFD-41C76A0A203B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95764993-7C67-4C0B-8AFD-41C76A0A203B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95764993-7C67-4C0B-8AFD-41C76A0A203B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F474C23D-FAC7-45BC-B21F-7915ABE7F461}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F474C23D-FAC7-45BC-B21F-7915ABE7F461}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F474C23D-FAC7-45BC-B21F-7915ABE7F461}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F474C23D-FAC7-45BC-B21F-7915ABE7F461}.Release|Any CPU.Build.0 = Release|Any CPU
+		{09804FCD-B506-4879-AE30-EF0DDCD87402}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{09804FCD-B506-4879-AE30-EF0DDCD87402}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{09804FCD-B506-4879-AE30-EF0DDCD87402}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{09804FCD-B506-4879-AE30-EF0DDCD87402}.Release|Any CPU.Build.0 = Release|Any CPU
+		{988A96F0-18D7-480A-9CDB-B804CD9B743C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{988A96F0-18D7-480A-9CDB-B804CD9B743C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{988A96F0-18D7-480A-9CDB-B804CD9B743C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{988A96F0-18D7-480A-9CDB-B804CD9B743C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{95764993-7C67-4C0B-8AFD-41C76A0A203B} = {4E1530E0-EC90-4B1A-ADEC-04B52B83056E}
+		{F474C23D-FAC7-45BC-B21F-7915ABE7F461} = {4E1530E0-EC90-4B1A-ADEC-04B52B83056E}
+		{09804FCD-B506-4879-AE30-EF0DDCD87402} = {4E1530E0-EC90-4B1A-ADEC-04B52B83056E}
+		{988A96F0-18D7-480A-9CDB-B804CD9B743C} = {50F530E7-FD4B-4548-989E-2A0F258468FE}
+	EndGlobalSection
+EndGlobal

--- a/src/OrderSignal.Api/OrderSignal.Api.csproj
+++ b/src/OrderSignal.Api/OrderSignal.Api.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/OrderSignal.Api/Program.cs
+++ b/src/OrderSignal.Api/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/src/OrderSignal.Api/Properties/launchSettings.json
+++ b/src/OrderSignal.Api/Properties/launchSettings.json
@@ -1,0 +1,38 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:22901",
+      "sslPort": 44372
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5192",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7229;http://localhost:5192",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/OrderSignal.Api/appsettings.Development.json
+++ b/src/OrderSignal.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/OrderSignal.Api/appsettings.json
+++ b/src/OrderSignal.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/OrderSignal.Contracts/Class1.cs
+++ b/src/OrderSignal.Contracts/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace OrderSignal.Contracts;
+
+public class Class1
+{
+
+}

--- a/src/OrderSignal.Contracts/OrderSignal.Contracts.csproj
+++ b/src/OrderSignal.Contracts/OrderSignal.Contracts.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/OrderSignal.Worker/OrderSignal.Worker.csproj
+++ b/src/OrderSignal.Worker/OrderSignal.Worker.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/OrderSignal.Worker/Program.cs
+++ b/src/OrderSignal.Worker/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/src/OrderSignal.Worker/Properties/launchSettings.json
+++ b/src/OrderSignal.Worker/Properties/launchSettings.json
@@ -1,0 +1,38 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:6593",
+      "sslPort": 44378
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5174",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7214;http://localhost:5174",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/OrderSignal.Worker/appsettings.Development.json
+++ b/src/OrderSignal.Worker/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/OrderSignal.Worker/appsettings.json
+++ b/src/OrderSignal.Worker/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/tests/OrderSignal.Unit/OrderSignal.Unit.csproj
+++ b/tests/OrderSignal.Unit/OrderSignal.Unit.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OrderSignal.Unit/UnitTest1.cs
+++ b/tests/OrderSignal.Unit/UnitTest1.cs
@@ -1,0 +1,10 @@
+namespace OrderSignal.Unit;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+
+    }
+}


### PR DESCRIPTION
### Summary
This PR adds the initial project structure for Order Signal.

### Changes
- Created README.md with project overview and tech stack
- Added ADR-0001 for monorepo decision
- Established roadmap for project phases
- Initialized .sln solution and projects (API, Worker, Contracts, Unit Tests)
- Added minimal API and Worker with sample endpoints

### Related issue
Closes #1